### PR TITLE
Analytics Dashboard function returns a list with UI/Server by default

### DIFF
--- a/R/analytics-app.R
+++ b/R/analytics-app.R
@@ -214,7 +214,7 @@ analytics_app <- function(data_storage, run_app = FALSE) {
     server = analytics_server(data_storage = data_storage)
   )
 
-  if (run_app) {
+  if (isTRUE(run_app)) {
     return(shiny::shinyApp(ui = sample_app$ui, server = sample_app$server))
   }
 

--- a/R/analytics-app.R
+++ b/R/analytics-app.R
@@ -204,11 +204,19 @@ analytics_server <- function(data_storage) {
 #'
 #' @param data_storage data_storage instance that will handle all backend read
 #' and writes.
+#' @param run_app flag that indicates if shinyApp should be called in the
+#' function or return the UI and Server instead.
 #'
 #' @export
-analytics_app <- function(data_storage) {
-  shiny::shinyApp(
+analytics_app <- function(data_storage, run_app = FALSE) {
+  sample_app <- list(
     ui = analytics_ui(),
     server = analytics_server(data_storage = data_storage)
   )
+
+  if (run_app) {
+    return(shiny::shinyApp(ui = sample_app$ui, server = sample_app$server))
+  }
+
+  sample_app
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -2,11 +2,13 @@ DataStorage
 JSON
 RStudio
 Rhinoverse
+UI
 analytics
 appsilon
 cloneable
 hostname
 json
 moduleServer
+shinyApp
 sqlfile
 sqlite

--- a/inst/examples/app/analytics/app.R
+++ b/inst/examples/app/analytics/app.R
@@ -33,4 +33,6 @@ if (Sys.getenv("R_CONFIG_ACTIVE") == "rsconnect") {
   )
 }
 
-analytics_app(data_storage = data_storage)
+sample_app <- analytics_app(data_storage = data_storage)
+
+shiny::shinyApp(ui = sample_app$ui, server = sample_app$server)

--- a/man/analytics_app.Rd
+++ b/man/analytics_app.Rd
@@ -4,11 +4,14 @@
 \alias{analytics_app}
 \title{Run example telemetry analytics dashboard}
 \usage{
-analytics_app(data_storage)
+analytics_app(data_storage, run_app = FALSE)
 }
 \arguments{
 \item{data_storage}{data_storage instance that will handle all backend read
 and writes.}
+
+\item{run_app}{flag that indicates if shinyApp should be called in the
+function or return the UI and Server instead.}
 }
 \description{
 Run example telemetry analytics dashboard


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #50

## Changes description

The analytics `analytics_app()` function returns a list with UI and Server so that `shiny::shinyApp()` can be called explicitely
