### PR TITLE
Track navigation in tabs/pages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: shiny.telemetry
 Type: Package
 Title: Shiny app usability logs and statistics
-Version: 0.0.9008
+Version: 0.0.9009
 Author: Appsilon Data Science <dev@appsilondatascience.com>
 Maintainer: Appsilon Data Science <dev@appsilondatascience.com>
 Description: Easy way for logging users activity and adding statistics panel to your Shiny app.

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -500,14 +500,17 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
         namespace = "shiny.telemetry"
       )
 
-      input_values[input_values %in% navigation_inputs] %>%
-        purrr::keep(~.x %in% navigation_inputs) %>%
-        purrr::map(~private$.log_event(
-          event = "input",
-          id = .x,
-          value = new[[name]],
-          session = session
-        ))
+      # Log initial value for navigation
+      input_values[names(input_values) %in% navigation_inputs] %>%
+        names() %>%
+        purrr::walk(function(.x) {
+
+          self$log_navigation_manual(
+            navigation_id = .x,
+            value = input_values[[.x]],
+            session = session
+          )
+        })
 
       shiny::observe({
         old_input_values <- session$userData$shiny_input_values

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -177,8 +177,10 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
       checkmate::assert_r6(session, "ShinySession")
 
       private$.log_input(
-        input = session$input, input_id = input_id, track_value = TRUE,
-        event_type = "navigation"
+        input_id = input_id,
+        track_value = TRUE,
+        event_type = "navigation",
+        session = session
       )
     },
 
@@ -196,7 +198,7 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
 
       logger::log_debug(
         "Writing 'navigation' event with ",
-        "id: '{input_id}' and value: '{value}'",
+        "id: '{navigation_id}' and value: '{value}'",
         namespace = "shiny.telemetry"
       )
 
@@ -280,6 +282,7 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
 
       shiny::observeEvent(input$browser_version, {
         browser <- input$browser_version
+
         shiny::validate(
           shiny::need(browser, "'browser_info_js' should be set in app head")
         )
@@ -478,7 +481,6 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
       session
     ) {
       checkmate::assert_r6(session, "ShinySession")
-      checkmate::assert_class(input, "reactivevalues")
       checkmate::assert_flag(track_values)
       checkmate::assert_character(excluded_inputs, null.ok = TRUE)
       checkmate::assert_character(navigation_inputs, null.ok = TRUE)

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -503,14 +503,13 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
       # Log initial value for navigation
       input_values[names(input_values) %in% navigation_inputs] %>%
         names() %>%
-        purrr::walk(function(.x) {
-
-          self$log_navigation_manual(
+        purrr::walk(
+          ~ self$log_navigation_manual(
             navigation_id = .x,
             value = input_values[[.x]],
             session = session
           )
-        })
+        )
 
       shiny::observe({
         old_input_values <- session$userData$shiny_input_values

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -127,9 +127,7 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
           navigation_inputs = navigation_input_id,
           session = session
         )
-      }
-
-      if (isFALSE(track_inputs) && !is.null(navigation_input_id)) {
+      } else {
         sapply(navigation_input_id, self$log_navigation)
       }
 

--- a/man/Telemetry.Rd
+++ b/man/Telemetry.Rd
@@ -62,6 +62,8 @@ telemetry$data_storage$read_user_data("2020-01-01", "2025-01-01") |> tail()
 \itemize{
 \item \href{#method-Telemetry-new}{\code{Telemetry$new()}}
 \item \href{#method-Telemetry-start_session}{\code{Telemetry$start_session()}}
+\item \href{#method-Telemetry-log_navigation}{\code{Telemetry$log_navigation()}}
+\item \href{#method-Telemetry-log_navigation_manual}{\code{Telemetry$log_navigation_manual()}}
 \item \href{#method-Telemetry-log_login}{\code{Telemetry$log_login()}}
 \item \href{#method-Telemetry-log_logout}{\code{Telemetry$log_logout()}}
 \item \href{#method-Telemetry-log_click}{\code{Telemetry$log_click()}}
@@ -116,6 +118,7 @@ Setup basic telemetry
   login = TRUE,
   logout = TRUE,
   browser_version = TRUE,
+  navigation_input_id = NULL,
   session = shiny::getDefaultReactiveDomain()
 )}\if{html}{\out{</div>}}
 }
@@ -136,11 +139,63 @@ track when a session starts. `TRUE` by default.}
 \item{\code{logout}}{flag that indicates if the basic telemetry should
 track when the session ends. `TRUE` by default.}
 
-\item{\code{browser_version}}{flag that indicates if the basic telemetry should
-track the browser version. `TRUE` by default.}
+\item{\code{browser_version}}{flag that indicates that the browser version
+should be tracked.`TRUE` by default.}
 
-\item{\code{session}}{The `session` object passed to function given to `shinyServer`.
-Default is `shiny::getDefaultReactiveDomain()`.}
+\item{\code{navigation_input_id}}{string or vector of strings that represent
+input ids and which value should be tracked as navigation events. i.e.
+a change in the value represent a navigation to a page or tab.
+By default, no navigation is tracked.}
+
+\item{\code{session}}{ShinySession object or NULL to identify the current
+Shiny session.}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Telemetry-log_navigation"></a>}}
+\if{latex}{\out{\hypertarget{method-Telemetry-log_navigation}{}}}
+\subsection{Method \code{log_navigation()}}{
+Log an input change as a navigation event
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Telemetry$log_navigation(input_id, session = shiny::getDefaultReactiveDomain())}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{input_id}}{string that identifies the generic input in the Shiny
+application so that the function can track and log changes to it.}
+
+\item{\code{session}}{ShinySession object or NULL to identify the current
+Shiny session.}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Telemetry-log_navigation_manual"></a>}}
+\if{latex}{\out{\hypertarget{method-Telemetry-log_navigation_manual}{}}}
+\subsection{Method \code{log_navigation_manual()}}{
+Log a navigation event manually by indicating the id (as input id)
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Telemetry$log_navigation_manual(
+  navigation_id,
+  value,
+  session = shiny::getDefaultReactiveDomain()
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{navigation_id}}{string that identifies navigation event.}
+
+\item{\code{value}}{string that indicates a value for the navigation}
+
+\item{\code{session}}{ShinySession object or NULL to identify the current
+Shiny session.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-log.R
+++ b/tests/testthat/test-log.R
@@ -109,6 +109,26 @@ test_that("log_input", {
     expect_message("Writing to user_log value: .*\"id\":\"sample_2\".*") %>%
     expect_message("Writing to user_log value: .*\"id\":\"sample_3\".*")
 
+  #
+  # Test simple usage of log_input
+  session$setInputs(uisidebar = "tab1")
+  expect_message(
+    telemetry$log_navigation(
+      input_id = "uisidebar",
+      session = session
+    ),
+    "Writing to user_log value: .*\"action\":\"navigation\".*\"value\":\"tab1\".*"
+  )
+
+  expect_message(
+    telemetry$log_navigation_manual(
+      navigation_id = "sample",
+      value = "tab2",
+      session = session
+    ),
+    "Writing to user_log value: .*\"action\":\"navigation\".*\"value\":\"tab2\".*"
+  )
+
   # Manual call to revert mock_binding of 'observeEvent'
   withr::deferred_run()
 })


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issues:

- closes #43 

## Changes description

note: This does not track URL changes

pre-requirements: merge of PR #59 as this builds upon that one

Allows to track navigation event in 3 different ways:

1. refer the input_id at `telemetry$start_session()`
2. observing an input with `telemetry$log_navigation(input_id)`
3. manually event recording with `telemetry$log_navigation_manual(id, value)`

## How to test?

Below are 2 app.R files that can be used for local test (note that you need to install latest version, or replace library call with `devtools::load_all()`)

1. First app tracks navigation from `telemetry$start_session()` call.
2. Second app tracks via explicit call `telemetry$log_navigation()` (which will get duplicate lines in database, one for input change and another for navigation event)

```R
library(shiny)
library(bslib)
library(shiny.telemetry)

nav_items <- function(prefix) {
  list(
    nav("a", paste(prefix, ": tab a content")),
    nav("b", paste(prefix, ": tab b content")),
    nav_item(
      tags$a(icon("github"), "Shiny", href = "https://github.com/rstudio/shiny", target = "_blank")
    ),
    nav_spacer(),
    nav_menu(
      "Other links", align = "right",
      nav("c", paste(prefix, ": tab c content")),
      nav_item(
        tags$a(icon("r-project"), "RStudio", href = "https://rstudio.com", target = "_blank")
      )
    )
  )
}

logger::log_threshold("DEBUG", namespace = "shiny.telemetry")

telemetry <- Telemetry$new(
  data_storage = DataStorageLogFile$new(
    log_file_path = tempfile(pattern = "user_stats", fileext = ".json"),
    session_file_path = tempfile(pattern = "session_details", fileext = ".json")
  )
  # data_storage = DataStorageRSQLite$new(
  #   db_path = file.path(getwd(), "..", "semantic.sqlite")
  # )
)

if (interactive()) {
  shinyApp(
    page_navbar(
      title = "page_navbar()",
      id = "nav",
      bg = "#0062cc",
      !!!nav_items("page_navbar()"),
      header = use_telemetry(),
      footer = div(
        style = "width:80%; margin: 0 auto",
        h4("navs_tab()"),
        navs_tab(!!!nav_items("navs_tab()")),
        h4("navs_pill()"),
        navs_pill(!!!nav_items("navs_pill()")),
        h4("navs_tab_card()"),
        navs_tab_card(!!!nav_items("navs_tab_card()")),
        h4("navs_pill_card()"),
        navs_pill_card(!!!nav_items("navs_pill_card()")),
        h4("navs_pill_list()"),
        navs_pill_list(!!!nav_items("navs_pill_list()"))
      )
    ),
    function(input, output, session) {
      telemetry$start_session(navigation_input_id = "nav")
    }
  )
}
```

```R
library(shiny)
library(semantic.dashboard)
library(shiny.telemetry)

ui <- dashboardPage(
  dashboardHeader(title = "Basic dashboard"),
  dashboardSidebar(sidebarMenu(
    menuItem(tabName = "dashboard", text = "Home", icon = icon("home")),
    menuItem(tabName = "widgets", text = "Another Tab", icon = icon("heart"))
  )),
  dashboardBody(
    use_telemetry(),
    tabItems(
      # First tab content
      tabItem(
        tabName = "dashboard",
        fluidRow(
          box(plotOutput("plot1", height = 250)),

          box(
            title = "Controls",
            sliderInput("slider", "Number of observations:", 1, 100, 50)
          )
        )
      ),

      # Second tab content
      tabItem(
        tabName = "widgets",
        h2("Widgets tab content")
      )
    )
  )
)

logger::log_threshold("DEBUG", namespace = "shiny.telemetry")

telemetry <- Telemetry$new(
  data_storage = DataStorageLogFile$new(
    log_file_path = tempfile(pattern = "user_stats", fileext = ".json"),
    session_file_path = tempfile(pattern = "session_details", fileext = ".json")
  )
  # data_storage = DataStorageRSQLite$new(
  #   db_path = file.path(getwd(), "..", "semantic.sqlite")
  # )
)

server <- function(input, output) {
  set.seed(122)
  histdata <- rnorm(500)

  telemetry$start_session()

  telemetry$log_navigation("uisidebar")
  telemetry$log_navigation_manual("uisidebar", "tab1")

  output$plot1 <- renderPlot({
    data <- histdata[seq_len(input$slider)]
    hist(data)
  })
}

shinyApp(ui, server)

```