### PR TITLE
Handle anonymous users as NULL on backend / data storage

### DIFF
--- a/R/data-storage.R
+++ b/R/data-storage.R
@@ -53,10 +53,8 @@ DataStorage <- R6::R6Class( # nolint object_name_linter
           time = lubridate::as_datetime(.data$time)
         )
 
-      if (NROW(db_data) > 0) {
-        return(db_data)
-      }
-
+      # Ensure standard value types always return on resutls
+      #  :: (id, value, username)
       db_data %>%
         dplyr::bind_rows(dplyr::tibble(
           time = as.POSIXct(character(0)),

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -673,7 +673,7 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
     },
 
     get_user = function(session = shiny::getDefaultReactiveDomain()) {
-      if (is.null(session) || is.null(session$user)) return("anonymous")
+      if (is.null(session) || is.null(session$user)) return(NULL)
       session$user
     }
   )

--- a/tests/testthat/helper-data_storage.R
+++ b/tests/testthat/helper-data_storage.R
@@ -20,6 +20,16 @@ test_common <- function(data_storage) {
   expect_true(checkmate::test_tibble(user_data_empty))
   expect_equal(NROW(user_data_empty), 0)
 
+  #
+  # Required fields when reading data (without any rows in data storage)
+  #  username, id and value are not stored directly, but within details field
+  user_data_empty %>%
+    colnames() %>%
+    sort() %>%
+    expect_equal(c(
+      "app_name", "date", "id", "session", "time", "type", "username", "value"
+    ))
+
   # Write and read data
   expect_error(data_storage$insert(), arg_missing_msg("app_name"))
   expect_error(data_storage$insert("dash"), arg_missing_msg("type"))
@@ -54,9 +64,20 @@ test_common <- function(data_storage) {
   expect_true(checkmate::test_tibble(user_data))
   expect_equal(NROW(user_data), 4)
 
+  # Empty call (no dates)
   data_storage$read_event_data() %>%
     NROW() %>%
     expect_equal(4)
+
+  #
+  # Required fields when reading data
+  #  username, id and value are not stored directly, but within details field
+  data_storage$read_event_data() %>%
+    colnames() %>%
+    sort() %>%
+    expect_equal(c(
+      "app_name", "date", "id", "session", "time", "type", "username", "value"
+    ))
 
   data_storage$insert(
     app_name = app_name,

--- a/tests/testthat/test-log.R
+++ b/tests/testthat/test-log.R
@@ -34,6 +34,18 @@ test_that("Telemetry tests with mock data_storage layer", {
   )
 
   #
+  # Test login and logout (last one shouldn't produce anything)
+
+  telemetry$log_login(
+    username = "ben",
+    session = session
+  ) %>% expect_message("Writing type=login value: .*\"username\":\"ben\".*")
+
+  telemetry$log_logout(
+    session = session
+  ) %>% expect_silent()
+
+  #
   # Test simple usage of log_input
   session$setInputs(sample = 53, sample2 = 31)
 


### PR DESCRIPTION
Issues:
- closes #83

## Changes description

* Changes default user written to data storage to NULL instead of "anonymous" string
* Adds tests to validate that read calls to empty tables return pre-defined columns _(so that it doesn't break analytics)_