### PR TITLE
Fix continuous deployment

### DIFF
--- a/.github/workflows/prepare_connect.yml
+++ b/.github/workflows/prepare_connect.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Install R
         uses: r-lib/actions/setup-r@v2
         with:
-          r-version: ${{ matrix.config.r }}
           use-public-rspm: true
 
       - name: Cache packages


### PR DESCRIPTION
### Changes

Use default R version in the deployment workflow.
