### PR TITLE
Fix problem with unsupported complex payload types

### DIFF
--- a/R/data-storage.R
+++ b/R/data-storage.R
@@ -148,6 +148,10 @@ DataStorage <- R6::R6Class( # nolint object_name_linter
       checkmate::assert_data_frame(x)
       checkmate::assert_string(column_name)
 
+      if (is.null(x[[column_name]])) {
+        return(x)
+      }
+
       x[[column_name]] <- x[[column_name]] %>%
         purrr::map(
           function(.x) {

--- a/tests/testthat/helper-data_storage.R
+++ b/tests/testthat/helper-data_storage.R
@@ -118,9 +118,7 @@ test_common_empty_details <- function(data_storage) {
 
   data_storage$insert(app_name = app_name, type = "without_session")
 
-  data_storage$read_event_data() %>%
-    NROW() %>%
-    expect_equal(1)
+  expect_equal(NROW(data_storage$read_event_data()), 1)
 }
 
 test_common_len_gt_1 <- function(data_storage) {

--- a/tests/testthat/helper-data_storage.R
+++ b/tests/testthat/helper-data_storage.R
@@ -150,22 +150,22 @@ test_common_len_gt_1_alt <- function(data_storage) {
   require(testthat)
   withr::defer(data_storage$close())
 
-  app_name <- "test_dashboard"
+  app_name <- "test_dashboard_len_gt_1_alt"
 
   data_storage$insert(
-    app_name = "app_name",
+    app_name = app_name,
     type = "without_session"
   )
 
   data_storage$insert(
-    app_name = "app_name",
+    app_name = app_name,
     type = "click",
     details = list(id = "some_button_id_2"),
     session = "some_session_id"
   )
 
   data_storage$insert(
-    app_name = "app_name",
+    app_name = app_name,
     type = "click",
     details = list(id = "vector_selected", value = 1:10, custom = 2),
     session = "some_session_id"
@@ -174,15 +174,13 @@ test_common_len_gt_1_alt <- function(data_storage) {
   result <- data_storage$read_event_data()
 
   result %>%
-    dplyr::filter(id == "vector_selected") %>%
+    dplyr::filter(.data$id == "vector_selected") %>%
     purrr::pluck("value") %>%
     expect_type("character")
 
   result %>%
-    dplyr::filter(id == "vector_selected") %>%
+    dplyr::filter(.data$id == "vector_selected") %>%
     purrr::pluck("value") %>%
     unname() %>%
     expect_equal(format(paste(1:10, collapse = ", ")))
 }
-
-

--- a/tests/testthat/helper-data_storage.R
+++ b/tests/testthat/helper-data_storage.R
@@ -109,3 +109,82 @@ test_common_data_storage <- function(data_storage) {
     NROW() %>%
     expect_equal(1)
 }
+
+test_common_empty_details <- function(data_storage) {
+  require(testthat)
+  withr::defer(data_storage$close())
+
+  app_name <- "test_dashboard_empty_details"
+
+  data_storage$insert(app_name = app_name, type = "without_session")
+
+  data_storage$read_event_data() %>%
+    NROW() %>%
+    expect_equal(1)
+}
+
+test_common_len_gt_1 <- function(data_storage) {
+  require(testthat)
+  withr::defer(data_storage$close())
+
+  app_name <- "test_dashboard"
+
+  data_storage$insert(
+    app_name = app_name,
+    type = "click",
+    details = list(id = "vector_selected", value = 1:10, custom = 2),
+    session = "some_session_id"
+  )
+
+  result <- data_storage$read_event_data()
+
+  result %>%
+    purrr::pluck("value") %>%
+    expect_type("character")
+
+  result %>%
+    purrr::pluck("value") %>%
+    unname() %>%
+    expect_equal(format(paste(1:10, collapse = ", ")))
+}
+
+test_common_len_gt_1_alt <- function(data_storage) {
+  require(testthat)
+  withr::defer(data_storage$close())
+
+  app_name <- "test_dashboard"
+
+  data_storage$insert(
+    app_name = "app_name",
+    type = "without_session"
+  )
+
+  data_storage$insert(
+    app_name = "app_name",
+    type = "click",
+    details = list(id = "some_button_id_2"),
+    session = "some_session_id"
+  )
+
+  data_storage$insert(
+    app_name = "app_name",
+    type = "click",
+    details = list(id = "vector_selected", value = 1:10, custom = 2),
+    session = "some_session_id"
+  )
+
+  result <- data_storage$read_event_data()
+
+  result %>%
+    dplyr::filter(id == "vector_selected") %>%
+    purrr::pluck("value") %>%
+    expect_type("character")
+
+  result %>%
+    dplyr::filter(id == "vector_selected") %>%
+    purrr::pluck("value") %>%
+    unname() %>%
+    expect_equal(format(paste(1:10, collapse = ", ")))
+}
+
+

--- a/tests/testthat/helper-data_storage.R
+++ b/tests/testthat/helper-data_storage.R
@@ -37,27 +37,27 @@ test_common_data_storage <- function(data_storage) {
   data_storage$insert(
     app_name = app_name,
     type = "without_session"
-  ) %>% expect_silent()
+  )
 
   data_storage$insert(
     app_name = app_name,
     type = "logout",
     session = "some_session_id"
-  ) %>% expect_silent()
+  )
 
   data_storage$insert(
     app_name = app_name,
     type = "click",
     details = list(id = "some_button_id"),
     session = "some_session_id"
-  ) %>% expect_silent()
+  )
 
   data_storage$insert(
     app_name = app_name,
     type = "click",
     details = list(id = "some_button_id_2"),
     session = "some_session_id"
-  ) %>% expect_silent()
+  )
 
   user_data <- data_storage$read_event_data(date_from, date_to)
 
@@ -85,7 +85,7 @@ test_common_data_storage <- function(data_storage) {
     details = list(id = "some_button_id_2"),
     session = "some_session_id",
     time = lubridate::as_datetime(lubridate::today() + 5)
-  ) %>% expect_silent()
+  )
 
   data_storage$insert(
     app_name = app_name,
@@ -93,7 +93,7 @@ test_common_data_storage <- function(data_storage) {
     details = list(id = "some_button_id_2"),
     session = "some_session_id",
     time = lubridate::as_datetime(lubridate::today() + 1)
-  ) %>% expect_silent()
+  )
 
   data_storage$read_event_data(
     lubridate::today() + 1,

--- a/tests/testthat/test-data_storage-logfile.R
+++ b/tests/testthat/test-data_storage-logfile.R
@@ -7,3 +7,67 @@ test_that("[LogFile] DataStorage should be able to insert and read", {
 
   test_common_data_storage(data_storage)
 })
+
+test_that("[LogFile] DataStorage should be able to insert and read events without details", {
+  log_file_path <- tempfile(fileext = ".txt")
+  withr::defer(file.remove(log_file_path))
+
+  data_storage <- DataStorageLogFile$new(log_file_path = log_file_path)
+  withr::defer(data_storage$close())
+
+  data_storage$insert(
+    app_name = "app_name",
+    type = "without_session"
+  ) %>% expect_silent()
+
+  data_storage$read_event_data() %>%
+    expect_silent() %>%
+    NROW() %>%
+    expect_equal(1)
+})
+
+test_that("[LogFile] DataStorage should be able to insert and read custom fields with length > 1", {
+  log_file_path <- tempfile(fileext = ".txt")
+  withr::defer(file.remove(log_file_path))
+
+  data_storage <- DataStorageLogFile$new(log_file_path = log_file_path)
+  withr::defer(data_storage$close())
+
+
+  data_storage$insert(
+    app_name = "app_name",
+    type = "without_session"
+  ) %>% expect_silent()
+
+  data_storage$insert(
+    app_name = "app_name",
+    type = "click",
+    details = list(id = "some_button_id_2"),
+    session = "some_session_id"
+  ) %>% expect_silent()
+
+  data_storage$insert(
+    app_name = "app_name",
+    type = "click",
+    details = list(id = "vector_selected", value = 1:10, custom = 2),
+    session = "some_session_id"
+  ) %>% expect_silent()
+
+  result <- data_storage$read_event_data() %>%
+    expect_silent()
+
+  result %>%
+    dplyr::filter(
+      id == "vector_selected"
+    ) %>%
+    purrr::pluck("value") %>%
+    expect_type("character")
+
+  result %>%
+    dplyr::filter(
+      id == "vector_selected"
+    ) %>%
+    purrr::pluck("value") %>%
+    unname() %>%
+    expect_equal(format(paste(1:10, collapse = ", ")))
+})

--- a/tests/testthat/test-data_storage-logfile.R
+++ b/tests/testthat/test-data_storage-logfile.R
@@ -13,75 +13,23 @@ test_that("[LogFile] DataStorage should be able to insert and read events withou
   withr::defer(file.remove(log_file_path))
 
   data_storage <- DataStorageLogFile$new(log_file_path = log_file_path)
-  withr::defer(data_storage$close())
-
-  data_storage$insert(app_name = "app_name", type = "without_session")
-
-  expect_equal(NROW(data_storage$read_event_data()), 1)
+  test_common_empty_details(data_storage)
 })
 
-test_that("[LogFile] DataStorage should be able to insert and read custom fields with length > 1", {
+test_that("[LogFile] Insert and read custom fields with length > 1", {
   log_file_path <- tempfile(fileext = ".txt")
   withr::defer(file.remove(log_file_path))
 
   data_storage <- DataStorageLogFile$new(log_file_path = log_file_path)
-  withr::defer(data_storage$close())
 
-  data_storage$insert(
-    app_name = "app_name",
-    type = "click",
-    details = list(id = "vector_selected", value = 1:10, custom = 2),
-    session = "some_session_id"
-  )
-
-  result <- data_storage$read_event_data()
-
-  result %>%
-    purrr::pluck("value") %>%
-    expect_type("character")
-
-  result %>%
-    purrr::pluck("value") %>%
-    unname() %>%
-    expect_equal(format(paste(1:10, collapse = ", ")))
+  test_common_len_gt_1(data_storage)
 })
 
-test_that("[LogFile] DataStorage should be able to insert and read custom fields with length > 1 on a pre-populated file", {
+test_that("[LogFile] Insert and read custom fields with length > 1 on a pre-populated file", {
   log_file_path <- tempfile(fileext = ".txt")
   withr::defer(file.remove(log_file_path))
 
   data_storage <- DataStorageLogFile$new(log_file_path = log_file_path)
-  withr::defer(data_storage$close())
 
-  data_storage$insert(
-    app_name = "app_name",
-    type = "without_session"
-  )
-
-  data_storage$insert(
-    app_name = "app_name",
-    type = "click",
-    details = list(id = "some_button_id_2"),
-    session = "some_session_id"
-  )
-
-  data_storage$insert(
-    app_name = "app_name",
-    type = "click",
-    details = list(id = "vector_selected", value = 1:10, custom = 2),
-    session = "some_session_id"
-  )
-
-  result <- data_storage$read_event_data()
-
-  result %>%
-    dplyr::filter(id == "vector_selected") %>%
-    purrr::pluck("value") %>%
-    expect_type("character")
-
-  result %>%
-    dplyr::filter(id == "vector_selected") %>%
-    purrr::pluck("value") %>%
-    unname() %>%
-    expect_equal(format(paste(1:10, collapse = ", ")))
+  test_common_len_gt_1_alt(data_storage)
 })

--- a/tests/testthat/test-data_storage-logfile.R
+++ b/tests/testthat/test-data_storage-logfile.R
@@ -15,15 +15,9 @@ test_that("[LogFile] DataStorage should be able to insert and read events withou
   data_storage <- DataStorageLogFile$new(log_file_path = log_file_path)
   withr::defer(data_storage$close())
 
-  data_storage$insert(
-    app_name = "app_name",
-    type = "without_session"
-  )
+  data_storage$insert(app_name = "app_name", type = "without_session")
 
-  data_storage$read_event_data() %>%
-    expect_silent() %>%
-    NROW() %>%
-    expect_equal(1)
+  expect_equal(NROW(data_storage$read_event_data()), 1)
 })
 
 test_that("[LogFile] DataStorage should be able to insert and read custom fields with length > 1", {

--- a/tests/testthat/test-data_storage-sqlite.R
+++ b/tests/testthat/test-data_storage-sqlite.R
@@ -6,3 +6,29 @@ test_that("[SQLite] DataStorage should be able to insert and read", {
 
   test_common_data_storage(data_storage)
 })
+
+test_that("[SQLite] DataStorage should be able to insert and read events without details", {
+  db_path <- tempfile(fileext = ".sqlite")
+  withr::defer(file.remove(db_path))
+
+  data_storage <- DataStorageSQLite$new(db_path = db_path)
+  test_common_empty_details(data_storage)
+})
+
+test_that("[SQLite] Insert and read custom fields with length > 1", {
+  db_path <- tempfile(fileext = ".sqlite")
+  withr::defer(file.remove(db_path))
+
+  data_storage <- DataStorageSQLite$new(db_path = db_path)
+
+  test_common_len_gt_1(data_storage)
+})
+
+test_that("[SQLite] Insert and read custom fields with length > 1 on a pre-populated file", {
+  db_path <- tempfile(fileext = ".sqlite")
+  withr::defer(file.remove(db_path))
+
+  data_storage <- DataStorageSQLite$new(db_path = db_path)
+
+  test_common_len_gt_1_alt(data_storage)
+})


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #127

~Note, the initial base branch of this PR is `fix-prepare-connect`, that should be merged before this one~

## Changes description

* [READ the data] Payload to event (under `details`) cannot support values with `length > 1` when reading from DataStorage and will convert them back to JSON.
* If it's an atomic vector, then it will print it as such

