### PR TITLE
shinyproxy user retrival

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: shiny.telemetry
 Title: 'Shiny' App Usage Telemetry
-Version: 0.2.0.9000
+Version: 0.2.0.9001
 Authors@R: c(
     person("André", "Veríssimo", , "opensource+andre@appsilon.com", role = c("aut", "cre")),
     person("Kamil", "Żyła", , "kamil@appsilon.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # shiny.telemetry (development version)
 
+### New Features
+
+
+- Updated `get_user` method to retrieve user in `shinyproxy` environment (#124).
+
 # shiny.telemetry 0.2.0
 
 ### New Features
@@ -8,7 +13,6 @@
 - Added MS SQL Server support (see `DataStorageMSSQLServer` class) (#128).
 - Added CI tests to all `DBI`-based `DataStorage` providers (#129).
 - Added optional parameter to `read_event_data` that filters by `app_name` (#129).
-- Updated `get_user` method to retrieve user in `shinyproxy` environment (#124)
 
 ### Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - Added MS SQL Server support (see `DataStorageMSSQLServer` class) (#128).
 - Added CI tests to all `DBI`-based `DataStorage` providers (#129).
 - Added optional parameter to `read_event_data` that filters by `app_name` (#129).
+- Updated `get_user` method to retrieve user in `shinyproxy` environment (#124)
 
 ### Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,6 @@
 
 ### New Features
 
-
 - Updated `get_user` method to retrieve user in `shinyproxy` environment (#124).
 
 # shiny.telemetry 0.2.0

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -721,10 +721,10 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
       force_username = NULL
     ) {
       if (!is.null(force_username)) return(force_username)
-      if (is.null(session) || is.null(session$user)){
-        if(is.null(Sys.getenv("SHINYPROXY_USERNAME"))){
+      if (is.null(session) || is.null(session$user)) {
+        if (is.null(Sys.getenv("SHINYPROXY_USERNAME"))) {
           return(NULL)
-        } else{
+        } else {
           return(Sys.getenv("SHINYPROXY_USERNAME"))
         }
       }

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -721,14 +721,13 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
       force_username = NULL
     ) {
       if (!is.null(force_username)) return(force_username)
-      if (is.null(session) || is.null(session$user)) {
-        if (is.null(Sys.getenv("SHINYPROXY_USERNAME"))) {
-          return(NULL)
-        } else {
-          return(Sys.getenv("SHINYPROXY_USERNAME"))
-        }
+      if (isFALSE(is.null(session)) && isFALSE(is.null(session$user))) {
+        return(session$user) # POSIT Connect
+      } else if (nzchar(Sys.getenv("SHINYPROXY_USERNAME"))) {
+        return(Sys.getenv("SHINYPROXY_USERNAME"))
+      } else {
+        return(NULL)
       }
-      session$user
     }
   )
 )

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -721,7 +721,13 @@ Telemetry <- R6::R6Class( # nolint object_name_linter
       force_username = NULL
     ) {
       if (!is.null(force_username)) return(force_username)
-      if (is.null(session) || is.null(session$user)) return(NULL)
+      if (is.null(session) || is.null(session$user)){
+        if(is.null(Sys.getenv("SHINYPROXY_USERNAME"))){
+          return(NULL)
+        } else{
+          return(Sys.getenv("SHINYPROXY_USERNAME"))
+        }
+      }
       session$user
     }
   )


### PR DESCRIPTION
In a ShinyProxy environment, the logged-in user will be automatically passed as an environmental variable instead of a session variable. Therefore, if the session is null, added an additional condition to check if username exists as an shinyproxy environmental variable using  Sys.getenv("SHINYPROXY_USERNAME").

Follow this steps to test in shinyproxy environment:

1) install docker and shinyproxy as mentioned in the official [shinyproxy documentation](https://www.shinyproxy.io/documentation/getting-started/)
2) pull the following docker image
`docker pull aruncoolprojects/demotelemetryshinyproxy`
3) overwrite the default shinyproxy configuration by creating a new application.yml in the shinyproxy root folder
**Note:**  In **container-volumes: ["<-path-to-your-local-folder>:/root/shiny/data"]**, Replace **<-path-to-your-local-folder>** with your local path such that you can see the telemetry logs.
        
<img width="503" alt="image" src="https://github.com/Appsilon/shiny.telemetry/assets/69163895/61ce7bdd-1bf2-4dcc-a828-f886e8c08e04">


*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue Fixed # As you can see first line has a username: shinyproxy (he is the user we configured in our application.yml)
<img width="1074" alt="image" src="https://github.com/Appsilon/shiny.telemetry/assets/69163895/1bfa1973-7c6c-4280-9af6-5af34e5d899d">


## Changes description

*Clearly and concisely describe what's in this pull request. Include screenshots, if necessary.*
