### PR TITLE
Fixes problems with #176

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Authors@R: c(
     person("Krystian", "Igras", , "krystian8207@gmail.com", role = "aut"),
     person("Recle", "Vibal", , "recle.vibal@appsilon.com", role = "aut"),
     person("Arun", "Kodati", , "arun.kodati@appsilon.com", role = "aut"),
+    person("Wahaduzzaman", "Khan", , "wahaduzzaman@appsilon.com", role = "aut"),
     person("Appsilon Sp. z o.o.", , , "opensource@appsilon.com", role = "cph")
   )
 Description: Enables instrumentation of 'Shiny' apps for tracking user

--- a/R/auxiliary.R
+++ b/R/auxiliary.R
@@ -116,6 +116,47 @@ build_query_mongodb <- function(date_from, date_to) {
   jsonlite::toJSON(query, auto_unbox = TRUE)
 }
 
+#' Create the connection string for mongodb
+#'
+#' @noRd
+#' @keywords internal
+#' @examples
+#' build_mongo_connection_string(
+#'   "localhost",
+#'   31,
+#'   "user",
+#'   "pass",
+#'   "authdb",
+#'   list("option1" = "value1", "option2" = "value2")
+#' )
+build_mongo_connection_string = function(
+    host, port, username, password, authdb, options
+) {
+  checkmate::assert_string(host)
+  checkmate::assert_int(port)
+  checkmate::assert_string(username, null.ok = TRUE)
+  checkmate::assert_string(password, null.ok = TRUE)
+  checkmate::assert_string(authdb, null.ok = TRUE)
+  checkmate::assert_list(options, null.ok = TRUE)
+
+  paste0(
+    "mongodb://",
+    sprintf("%s:%s@", username, password),
+    host,
+    ":",
+    port,
+    sprintf("/%s", authdb %||% ""),
+    ifelse(
+      isFALSE(is.null(options)),
+      sprintf(
+        "?%s",
+        paste(names(options), "=", options, collapse = "&", sep = "")
+      ),
+      ""
+    )
+  )
+}
+
 #' Process a row's detail (from DB) in JSON format to a data.frame
 #'
 #' @param details_json string containing details a valid JSON, NULL or NA

--- a/R/auxiliary.R
+++ b/R/auxiliary.R
@@ -130,8 +130,7 @@ build_query_mongodb <- function(date_from, date_to) {
 #'   list("option1" = "value1", "option2" = "value2")
 #' )
 build_mongo_connection_string <- function(
-    hostname, port, username, password, authdb, options
-) {
+    hostname, port, username, password, authdb, options) {
   checkmate::assert_string(hostname)
   checkmate::assert_int(port)
   checkmate::assert_string(username, null.ok = TRUE)

--- a/R/auxiliary.R
+++ b/R/auxiliary.R
@@ -129,8 +129,8 @@ build_query_mongodb <- function(date_from, date_to) {
 #'   "authdb",
 #'   list("option1" = "value1", "option2" = "value2")
 #' )
-build_mongo_connection_string = function(
-    host, port, username, password, authdb, options
+build_mongo_connection_string <- function(
+  host, port, username, password, authdb, options
 ) {
   checkmate::assert_string(host)
   checkmate::assert_int(port)

--- a/R/auxiliary.R
+++ b/R/auxiliary.R
@@ -130,9 +130,9 @@ build_query_mongodb <- function(date_from, date_to) {
 #'   list("option1" = "value1", "option2" = "value2")
 #' )
 build_mongo_connection_string <- function(
-  host, port, username, password, authdb, options
+    hostname, port, username, password, authdb, options
 ) {
-  checkmate::assert_string(host)
+  checkmate::assert_string(hostname)
   checkmate::assert_int(port)
   checkmate::assert_string(username, null.ok = TRUE)
   checkmate::assert_string(password, null.ok = TRUE)
@@ -142,7 +142,7 @@ build_mongo_connection_string <- function(
   paste0(
     "mongodb://",
     sprintf("%s:%s@", username, password),
-    host,
+    hostname,
     ":",
     port,
     sprintf("/%s", authdb %||% ""),

--- a/R/data-storage-mongodb.R
+++ b/R/data-storage-mongodb.R
@@ -72,18 +72,6 @@ DataStorageMongoDB <- R6::R6Class( # nolint object_name.
         digest::digest(password, algo = "sha256")
       }
 
-      options_debug <- if (is.null(options)) {
-        "(empty)"
-      } else {
-        jsonlite::toJSON(options, auto_unbox = TRUE)
-      }
-
-      ssl_options_debug <- if (is.null(ssl_options)) {
-        "(empty)"
-      } else {
-        jsonlite::toJSON(unclass(mongolite::ssl_options()), auto_unbox = TRUE)
-      }
-
       logger::log_debug(
         "Parameters for MongoDB:\n",
         "  *          username: {username %||% \"(empty)\"}\n",
@@ -91,8 +79,9 @@ DataStorageMongoDB <- R6::R6Class( # nolint object_name.
         "  *     hostname:port: {hostname}:{port}\n",
         "  *           db name: {dbname}\n",
         "  *            authdb: {authdb %||% \"(empty)\"}\n",
-        "  *           options: {options_debug}\n",
-        "  *       ssl_options: {ssl_options_debug}\n",
+        "  *           options: {jsonlite::toJSON(options, auto_unbox = TRUE)}\n",
+        "  *       ssl_options: ",
+        "{jsonlite::toJSON(unclass(mongolite::ssl_options()), auto_unbox = TRUE)}\n",
         namespace = "shiny.telemetry"
       )
 

--- a/R/data-storage-mongodb.R
+++ b/R/data-storage-mongodb.R
@@ -156,10 +156,12 @@ DataStorageMongoDB <- R6::R6Class( # nolint object_name.
           tidyr::unnest(cols = "details") %>%
           dplyr::mutate(time = lubridate::as_datetime(as.integer(time / 1000)))
 
-        if (!"value" %in% colnames(result)) {
-          dplyr::mutate(result, value = NA_character_)
-        } else {
+        # Force value column to be a character data type
+        if ("value" %in% colnames(result)) {
           dplyr::mutate(result, value = format(value))
+        } else {
+          # If there is no column, then it should still be a character data type
+          dplyr::mutate(result, value = NA_character_)
         }
       } else {
         dplyr::tibble(

--- a/R/data-storage-mongodb.R
+++ b/R/data-storage-mongodb.R
@@ -8,11 +8,10 @@
 #'
 #' @examples
 #' \dontrun{
-#' data_storage <- DataStorageMariaDB$new(
-#'   url = "mongodb://localhost",
+#' data_storage <- DataStorageMongoDB$new(
+#'   host = "localhost",
 #'   db = "test",
-#'   collection = "test",
-#'   options = mongolite::ssl_options()
+#'   ssl_options = mongolite::ssl_options()
 #' )
 #' data_storage$insert("example", "test_event", "session1")
 #' data_storage$insert("example", "input", "s1", list(id = "id1"))
@@ -42,7 +41,6 @@ DataStorageMongoDB <- R6::R6Class( # nolint object_name.
     #' @param password the password for authentication (optional).
     #' @param authdb the default authentication database (optional).
     #' @param db name of database (default is "shiny_telemetry").
-    #' @param collection name of collection (default is "event_log").
     #' @param options Additional connection options in a named list format
     #' (e.g., list(ssl = "true", replicaSet = "myreplicaset")) (optional).
     #' @param ssl_options additional connection options such as SSL keys/certs
@@ -55,72 +53,46 @@ DataStorageMongoDB <- R6::R6Class( # nolint object_name.
       password = NULL,
       authdb = NULL,
       db = "shiny_telemetry",
-      collection = "event_log",
       options = NULL,
       ssl_options = mongolite::ssl_options()
-    ) {
-      connection_string <- private$create_connection_string(
-        host = host,
-        port = port,
-        username = username,
-        password = password,
-        authdb = authdb,
-        options = options
-      )
-      private$connect(url = connection_string, db, collection, options = ssl_options)
-      private$db_name <- db
-      private$collection_name <- collection
-    }
-  ),
-  active = list(
-
-    #' @field event_bucket string that identifies the bucket to store user
-    #' related and action data
-    event_bucket = function() private$collection_name
-  ),
-  #
-  # Private
-  private = list(
-    # Private Fields
-    db_con = NULL,
-    db_name = NULL,
-    collection_name = NULL,
-
-    # Private methods
-    create_connection_string = function(
-      host, port, username, password, authdb, options
     ) {
       # create the connection string for mongodb
       checkmate::assert_string(host)
       checkmate::assert_int(port)
       checkmate::assert_string(username, null.ok = TRUE)
       checkmate::assert_string(password, null.ok = TRUE)
+      checkmate::assert_string(authdb, null.ok = TRUE)
+      checkmate::assert_string(db)
       checkmate::assert_list(options, null.ok = TRUE)
+      checkmate::assert_list(ssl_options, null.ok = TRUE)
 
-      if (!is.null(username) && !is.null(password)) {
-        auth_string <- paste0(username, ":", password, "@")
-      } else {
-        auth_string <- ""
-      }
+      private$connect(
+        url = build_mongo_connection_string(
+          host = host,
+          port = port,
+          username = username,
+          password = password,
+          authdb = authdb,
+          options = options
+        ),
+        db,
+        options = ssl_options
+      )
+    }
+  ),
+  #
+  # Private
+  private = list(
+    # Private Fields
+    db_con = NULL,
 
-      authdb_string <- ifelse(!is.null(authdb), paste0("/", authdb), "")
-
-      connection_string <- paste0("mongodb://", auth_string, host, ":", port, authdb_string)
-      # Add options if provided
-      if (!is.null(options)) {
-        options_string <- paste0("?", paste(names(options), "=", options, collapse = "&"))
-        connection_string <- paste0(connection_string, options_string)
-      }
-
-      return(connection_string)
-    },
-
-    connect = function(url, db, collection, options) {
+    # Private methods
+    connect = function(url, db, options) {
       # Initialize connection with database
       private$db_con <- mongolite::mongo(
         url = url,
         db = db,
-        collection = collection,
+        collection = self$event_bucket,
         options = options
       )
     },
@@ -133,7 +105,9 @@ DataStorageMongoDB <- R6::R6Class( # nolint object_name.
       checkmate::assert_choice(bucket, choices = c(self$event_bucket))
       checkmate::assert_list(values)
 
-      values$details <- jsonlite::fromJSON(values$details)
+      if (!is.null(values$details)) {
+        values$details <- jsonlite::fromJSON(values$details)
+      }
 
       private$db_con$insert(values, auto_unbox = TRUE, POSIXt = "epoch")
     },

--- a/R/data-storage-mongodb.R
+++ b/R/data-storage-mongodb.R
@@ -104,7 +104,6 @@ DataStorageMongoDB <- R6::R6Class( # nolint object_name.
     write = function(values, bucket) {
       checkmate::assert_choice(bucket, choices = c(self$event_bucket))
       checkmate::assert_list(values)
-
       if (!is.null(values$details)) {
         values$details <- jsonlite::fromJSON(values$details)
       }
@@ -124,7 +123,10 @@ DataStorageMongoDB <- R6::R6Class( # nolint object_name.
         event_data %>%
           dplyr::tibble() %>%
           tidyr::unnest(cols = "details") %>%
-          dplyr::mutate(time = lubridate::as_datetime(as.integer(time / 1000)))
+          dplyr::mutate(
+            time = lubridate::as_datetime(as.integer(time / 1000)),
+            value = as.character(value)
+          )
       } else {
         dplyr::tibble(
           app_name = character(),

--- a/man/DataStorageMongoDB.Rd
+++ b/man/DataStorageMongoDB.Rd
@@ -9,11 +9,10 @@ unified API for read/write operations
 }
 \examples{
 \dontrun{
-data_storage <- DataStorageMariaDB$new(
-  url = "mongodb://localhost",
+data_storage <- DataStorageMongoDB$new(
+  host = "localhost",
   db = "test",
-  collection = "test",
-  options = mongolite::ssl_options()
+  ssl_options = mongolite::ssl_options()
 )
 data_storage$insert("example", "test_event", "session1")
 data_storage$insert("example", "input", "s1", list(id = "id1"))
@@ -31,14 +30,6 @@ data_storage$close()
 }
 \section{Super class}{
 \code{\link[shiny.telemetry:DataStorage]{shiny.telemetry::DataStorage}} -> \code{DataStorageMongoDB}
-}
-\section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
-\item{\code{event_bucket}}{string that identifies the bucket to store user
-related and action data}
-}
-\if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -63,13 +54,12 @@ related and action data}
 Initialize the data storage class
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{DataStorageMongoDB$new(
-  host = "localhost",
+  hostname = "localhost",
   port = 27017,
   username = NULL,
   password = NULL,
   authdb = NULL,
-  db = "shiny_telemetry",
-  collection = "event_log",
+  dbname = "shiny_telemetry",
   options = NULL,
   ssl_options = mongolite::ssl_options()
 )}\if{html}{\out{</div>}}
@@ -78,7 +68,7 @@ Initialize the data storage class
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{host}}{the hostname or IP address of the MongoDB server.}
+\item{\code{hostname}}{the hostname or IP address of the MongoDB server.}
 
 \item{\code{port}}{the port number of the MongoDB server (default is 27017).}
 
@@ -88,9 +78,7 @@ Initialize the data storage class
 
 \item{\code{authdb}}{the default authentication database (optional).}
 
-\item{\code{db}}{name of database (default is "shiny_telemetry").}
-
-\item{\code{collection}}{name of collection (default is "event_log").}
+\item{\code{dbname}}{name of database (default is "shiny_telemetry").}
 
 \item{\code{options}}{Additional connection options in a named list format
 (e.g., list(ssl = "true", replicaSet = "myreplicaset")) (optional).}

--- a/tests/testthat/helper-init-data-storage.R
+++ b/tests/testthat/helper-init-data-storage.R
@@ -88,8 +88,7 @@ init_test_mongodb <- function(.local_envir = parent.frame()) {
     password = Sys.getenv("TEST_MONGODB_PASSWORD"),
     host = Sys.getenv("TEST_MONGODB_HOSTNAME"),
     port = Sys.getenv("TEST_MONGODB_PORT"),
-    db = Sys.getenv("TEST_MONGODB_DBNAME"),
-    collection = Sys.getenv("TEST_MONGODB_COLLECTION")
+    db = Sys.getenv("TEST_MONGODB_DBNAME")
   )
 
   testthat::skip_on_cran()

--- a/tests/testthat/test-auxiliary_functions.R
+++ b/tests/testthat/test-auxiliary_functions.R
@@ -47,3 +47,73 @@ test_that("Build valid SQL query", {
     )
 
 })
+
+test_that("build_mongo_connection_string: Build valid string with NULL", {
+  expect_equal(
+    build_mongo_connection_string(
+      host = "localhost",
+      port = 27017,
+      username = NULL,
+      password = NULL,
+      authdb = NULL,
+      options = NULL
+    ),
+    "mongodb://localhost:27017"
+  )
+})
+
+test_that("build_mongo_connection_string: Build valid string with user and pass", {
+  expect_equal(
+    build_mongo_connection_string(
+      host = "localhost",
+      port = 27017,
+      username = "a_user",
+      password = "a_pass",
+      authdb = NULL,
+      options = NULL
+    ),
+    "mongodb://a_user:a_pass@localhost:27017"
+  )
+})
+
+test_that("build_mongo_connection_string: Build valid string with `authdb`", {
+  expect_equal(
+    build_mongo_connection_string(
+      host = "localhost",
+      port = 27017,
+      username = NULL,
+      password = NULL,
+      authdb = "path_to_authdb",
+      options = NULL
+    ),
+    "mongodb://localhost:27017/path_to_authdb"
+  )
+})
+
+test_that("build_mongo_connection_string: Build valid string with `options`", {
+  expect_equal(
+    build_mongo_connection_string(
+      host = "localhost",
+      port = 27017,
+      username = NULL,
+      password = NULL,
+      authdb = NULL,
+      options = list("option1" = "value1", "option2" = "value2")
+    ),
+    "mongodb://localhost:27017?option1=value1&option2=value2"
+  )
+})
+
+test_that("build_mongo_connection_string: Build valid string with all parameters", {
+  expect_equal(
+    build_mongo_connection_string(
+      host = "localhost",
+      port = 27017,
+      username = "a_user",
+      password = "a_pass",
+      authdb = "path_to_authdb",
+      options = list("option1" = "value1", "option2" = "value2")
+    ),
+    "mongodb://a_user:a_pass@localhost:27017/path_to_authdb?option1=value1&option2=value2"
+  )
+})

--- a/tests/testthat/test-auxiliary_functions.R
+++ b/tests/testthat/test-auxiliary_functions.R
@@ -58,7 +58,7 @@ test_that("build_mongo_connection_string: Build valid string with NULL", {
       authdb = NULL,
       options = NULL
     ),
-    "mongodb://localhost:27017"
+    "mongodb://localhost:27017/"
   )
 })
 
@@ -72,7 +72,7 @@ test_that("build_mongo_connection_string: Build valid string with user and pass"
       authdb = NULL,
       options = NULL
     ),
-    "mongodb://a_user:a_pass@localhost:27017"
+    "mongodb://a_user:a_pass@localhost:27017/"
   )
 })
 
@@ -100,7 +100,7 @@ test_that("build_mongo_connection_string: Build valid string with `options`", {
       authdb = NULL,
       options = list("option1" = "value1", "option2" = "value2")
     ),
-    "mongodb://localhost:27017?option1=value1&option2=value2"
+    "mongodb://localhost:27017/?option1=value1&option2=value2"
   )
 })
 


### PR DESCRIPTION
Part of #174

### Changes description

* Fixes documentation
* Fixes examples for DataStorageMongoDB
* Fixes functionality
  * Read from DB was not working properly
* Fixes connection string
  * Empty `authdb` needs to be `/`
  * Adds tests to connection string

### Definition of done

- [x] *Have you read the [Contributing Guidelines](https://github.com/Appsilon/shiny.telemetry/blob/main/CONTRIBUTING.md)?*
- [x] ~`NEWS.md` file has been updated~
- [x] ~Development version has been bumped (`x.y.z.90XX`)~
- [x] ~Issue has been linked with this PR _(via [Closing keywords](https://docs.github.com/articles/closing-issues-using-keywords) or right sidebar under `Development`)_~
