### PR TITLE
Fixes problem when `log_all_inputs` is called manually

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: shiny.telemetry
 Title: 'Shiny' App Usage Telemetry
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: c(
     person("André", "Veríssimo", , "opensource+andre@appsilon.com", role = c("aut", "cre")),
     person("Kamil", "Żyła", , "kamil@appsilon.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# shiny.telemetry (development)
+
+### New Features
+
+- Added `log_errors` method that allows users to track errors in their Shiny apps outside `start_session` (#189).
+
+### Bug Fixes
+
+- Fixed problem with `log_all_inputs` call that crashed telemetry (#187).
+- Fixed error appearing in analytics app (#188).
+
 # shiny.telemetry 0.3.0
 
 ### New Features

--- a/R/prepare-admin-panel.R
+++ b/R/prepare-admin-panel.R
@@ -917,7 +917,13 @@ prepare_admin_panel_components <- function(
 
   selected_session_data <- shiny::reactive({
     shiny::validate(shiny::need(selected_session(), label = "selected_session"))
-    selected_log_data() %>%
+    selected_data <- selected_log_data()
+
+    if(!'message' %in% names(selected_data)) {
+      selected_data$message <- NA
+    }
+
+    selected_data %>%
       dplyr::filter(
         .data$type %in% c("login", "logout", "input", "navigation", "error"),
         session == selected_session()
@@ -927,7 +933,7 @@ prepare_admin_panel_components <- function(
         content = dplyr::case_when(
           type %in% c("login", "logout") ~ type,
           type == "input" ~ sprintf("Input: %s <br /> Value: %s", id, value),
-          type == "navigation" ~ sprintf("Navigated: %s", id),
+          type == "navigation" ~ sprintf("Navigated (%s): %s", id, value),
           type == "error" ~ sprintf("Error: %s", message),
         ),
         style = "text-align: left;",

--- a/R/prepare-admin-panel.R
+++ b/R/prepare-admin-panel.R
@@ -919,7 +919,7 @@ prepare_admin_panel_components <- function(
     shiny::validate(shiny::need(selected_session(), label = "selected_session"))
     selected_data <- selected_log_data()
 
-    if(!'message' %in% names(selected_data)) {
+    if (!"message" %in% names(selected_data)) {
       selected_data$message <- NA
     }
 

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -211,71 +211,7 @@ Telemetry <- R6::R6Class( # nolint object_name.
       }
 
       if (isTRUE(track_errors)) {
-        if ("onUnhandledError" %in% ls(getNamespace("shiny"))) {
-          # onUnhandledError handler is only available in shiny >= 1.8.1
-          shiny::onUnhandledError(function(error) {
-            self$log_error(
-              output_id = "global",
-              message = conditionMessage(error)
-            )
-          })
-        } else {
-          # In shiny < 1.8.1, we fallback to using the `shiny.error` option and
-          # if that is already set, we track the `shiny:error` javascript event.
-          lifecycle::deprecate_warn(
-            when = as.character(utils::packageVersion("shiny")),
-            what = "Telemetry$start_session(track_errors = \"is not fully enabled \")",
-            details = c(
-              paste(
-                "Update the shiny package to version `1.8.1` or higher to",
-                "enable logging of all errors.",
-                sep = " "
-              ),
-              paste(
-                "Until then, shiny.telemetry can only reliably detect errors",
-                "triggered by the `shiny:error` javacript event.",
-                sep = " "
-              )
-            ),
-            env = getNamespace("shiny")
-          )
-
-          if (is.null(getOption("shiny.error"))) {
-            options(
-              "shiny.error" = function(.envir = parent.frame()) {
-                # make sure id is a string without spaces
-                output_id <- paste(
-                  gsub(
-                    " |\t|\r",
-                    "_",
-                    as.character(.envir$e$call %||% "global")
-                  ),
-                  collapse = "__"
-                )
-
-                self$log_error(
-                  output_id = output_id,
-                  message = .envir$e$message %||% "Unknown error.",
-                  session = session
-                )
-              }
-            )
-
-            # Restore previous option
-            shiny::onSessionEnded(
-              fun = function() options("shiny.error" = NULL),
-              session = session
-            )
-          } else {
-            shiny::observeEvent(input[[private$.track_error_id]], {
-              self$log_error(
-                output_id = input[[private$.track_error_id]]$output_id,
-                message = input[[private$.track_error_id]]$message,
-                session = session
-              )
-            })
-          }
-        }
+        self$log_errors(session)
       }
       NULL
     },
@@ -504,6 +440,7 @@ Telemetry <- R6::R6Class( # nolint object_name.
         navigation_inputs = c(),
         excluded_inputs_regex = excluded_inputs_regex,
         include_input_ids = include_input_ids,
+        track_errors = FALSE,
         session = session
       )
     },
@@ -606,7 +543,7 @@ Telemetry <- R6::R6Class( # nolint object_name.
       )
     },
     #' @description
-    #' Log an error event
+    #' Log a manual error event
     #'
     #' @param output_id string that refers to the output element where the error occurred.
     #' @param message string that describes the error.
@@ -631,6 +568,80 @@ Telemetry <- R6::R6Class( # nolint object_name.
         details = list(output_id = output_id, message = message),
         session = session
       )
+    },
+
+    #' @description
+    #' Track errors as they occur in observe and reactive
+    #'
+    #' @param session `ShinySession` object or NULL to identify the current Shiny session.
+    #'
+    #' @return Nothing. This method is called for side effects.
+    log_errors = function(session = shiny::getDefaultReactiveDomain()) {
+      if ("onUnhandledError" %in% ls(getNamespace("shiny"))) {
+        # onUnhandledError handler is only available in shiny >= 1.8.1
+        shiny::onUnhandledError(function(error) {
+          self$log_error(
+            output_id = "global",
+            message = conditionMessage(error)
+          )
+        })
+      } else {
+        # In shiny < 1.8.1, we fallback to using the `shiny.error` option and
+        # if that is already set, we track the `shiny:error` javascript event.
+        lifecycle::deprecate_warn(
+          when = as.character(utils::packageVersion("shiny")),
+          what = "Telemetry$start_session(track_errors = \"is not fully enabled \")",
+          details = c(
+            paste(
+              "Update the shiny package to version `1.8.1` or higher to",
+              "enable logging of all errors.",
+              sep = " "
+            ),
+            paste(
+              "Until then, shiny.telemetry can only reliably detect errors",
+              "triggered by the `shiny:error` javacript event.",
+              sep = " "
+            )
+          ),
+          env = getNamespace("shiny")
+        )
+
+        if (is.null(getOption("shiny.error"))) {
+          options(
+            "shiny.error" = function(.envir = parent.frame()) {
+              # make sure id is a string without spaces
+              output_id <- paste(
+                gsub(
+                  " |\t|\r",
+                  "_",
+                  as.character(.envir$e$call %||% "global")
+                ),
+                collapse = "__"
+              )
+
+              self$log_error(
+                output_id = output_id,
+                message = .envir$e$message %||% "Unknown error.",
+                session = session
+              )
+            }
+          )
+
+          # Restore previous option
+          shiny::onSessionEnded(
+            fun = function() options("shiny.error" = NULL),
+            session = session
+          )
+        } else {
+          shiny::observeEvent(session$input[[private$.track_error_id]], {
+            self$log_error(
+              output_id = session$input[[private$.track_error_id]]$output_id,
+              message = session$input[[private$.track_error_id]]$message,
+              session = session
+            )
+          })
+        }
+      }
     }
   ),
   active = list(
@@ -682,7 +693,7 @@ Telemetry <- R6::R6Class( # nolint object_name.
       track_values,
       excluded_inputs,
       navigation_inputs,
-      track_errors,
+      track_errors = TRUE,
       excluded_inputs_regex = NULL,
       include_input_ids = NULL,
       session

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -440,7 +440,7 @@ Telemetry <- R6::R6Class( # nolint object_name.
         navigation_inputs = c(),
         excluded_inputs_regex = excluded_inputs_regex,
         include_input_ids = include_input_ids,
-        track_errors = FALSE,
+        track_errors = TRUE,
         session = session
       )
     },

--- a/inst/examples/app/instrumentation/app.R
+++ b/inst/examples/app/instrumentation/app.R
@@ -115,11 +115,6 @@ shinyApp(ui = ui, server = function(input, output, session) {
     navigation_input_id = "uisidebar"
   )
 
-  # observe({
-  #   input$apply_slider
-  #   stop("bla")
-  # })
-
   # server code
   output$plot1 <- renderPlot({
     input$apply_slider

--- a/inst/examples/app/instrumentation/app.R
+++ b/inst/examples/app/instrumentation/app.R
@@ -115,6 +115,11 @@ shinyApp(ui = ui, server = function(input, output, session) {
     navigation_input_id = "uisidebar"
   )
 
+  # observe({
+  #   input$apply_slider
+  #   stop("bla")
+  # })
+
   # server code
   output$plot1 <- renderPlot({
     input$apply_slider

--- a/man/Telemetry.Rd
+++ b/man/Telemetry.Rd
@@ -120,6 +120,7 @@ file.remove(db_path)
 \item \href{#method-Telemetry-log_input_manual}{\code{Telemetry$log_input_manual()}}
 \item \href{#method-Telemetry-log_custom_event}{\code{Telemetry$log_custom_event()}}
 \item \href{#method-Telemetry-log_error}{\code{Telemetry$log_error()}}
+\item \href{#method-Telemetry-log_errors}{\code{Telemetry$log_errors()}}
 \item \href{#method-Telemetry-clone}{\code{Telemetry$clone()}}
 }
 }
@@ -553,7 +554,7 @@ Nothing. This method is called for side effects.
 \if{html}{\out{<a id="method-Telemetry-log_error"></a>}}
 \if{latex}{\out{\hypertarget{method-Telemetry-log_error}{}}}
 \subsection{Method \code{log_error()}}{
-Log an error event
+Log a manual error event
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Telemetry$log_error(
   output_id,
@@ -569,6 +570,26 @@ Log an error event
 
 \item{\code{message}}{string that describes the error.}
 
+\item{\code{session}}{\code{ShinySession} object or NULL to identify the current Shiny session.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Nothing. This method is called for side effects.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Telemetry-log_errors"></a>}}
+\if{latex}{\out{\hypertarget{method-Telemetry-log_errors}{}}}
+\subsection{Method \code{log_errors()}}{
+Track errors as they occur in observe and reactive
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Telemetry$log_errors(session = shiny::getDefaultReactiveDomain())}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
 \item{\code{session}}{\code{ShinySession} object or NULL to identify the current Shiny session.}
 }
 \if{html}{\out{</div>}}


### PR DESCRIPTION
Closes #187 and #188

### Changes description

1. Fixes bug with `log_all_inputs`
2. Adds `log_errors` method
3. Fixes analytics app

### How to test?

1. Run example app on #187 
2. (internal, making sure that errors are being logged)
3. Run sample app and then ppen analytics app that doesn't have any logged error
    - Click on session tab
    - Click on any session (that doesn't have error)
    - (visual guide below)

### Error on [deployed app](https://connect.appsilon.com/shiny_telemetry-analytics/) 

![image](https://github.com/user-attachments/assets/75cb3593-85ef-4881-accd-921252b3f839)

### Fixed in this PR (error + annotation)

![image](https://github.com/user-attachments/assets/580c53f3-5c3a-468a-88d8-06e2000a205f)


### Definition of done

- [x] *Have you read the [Contributing Guidelines](https://github.com/Appsilon/shiny.telemetry/blob/main/CONTRIBUTING.md)?*
- [x] `NEWS.md` file has been updated
- [x] Development version has been bumped (`x.y.z.90XX`)
- [x] Issue has been linked with this PR _(via [Closing keywords](https://docs.github.com/articles/closing-issues-using-keywords) or right sidebar under `Development`)_
