### PR TITLE
194 feature support multiple application in analytics app

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@ cran-comments.md
 CRAN-SUBMISSION
 ^docs$
 ^CRAN-SUBMISSION$
+.devcontainer

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/r-rig:latest": {
-      "version": "4.3.1",
+      "version": "release",
       "vscodeRSupport": "languageserver",
       "installRadian": true,
       "installDevTools": true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/rocker-org/devcontainer-features/r-rig:latest": {
+      "version": "4.3.1",
+      "vscodeRSupport": "languageserver",
+      "installRadian": true,
+      "installDevTools": true
+    },
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+      "packages": "libpq-dev"
+    },
+    "ghcr.io/rocker-org/devcontainer-features/r-dependent-packages:0": {},
+    "ghcr.io/rocker-org/devcontainer-features/rstudio-server:0": {
+      "version": "daily"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "forwardPorts": [
+    8787
+  ],
+  "portsAttributes": {
+    "8787": {
+      "label": "RStudio IDE"
+    }
+  },
+  "remoteEnv": {
+    "PKG_SYSREQS": "true",
+    "RENV_CONFIG_PAK_ENABLED": "TRUE"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "REditorSupport.r",
+        "github.copilot"
+      ],
+      "settings": {
+        "r.rterm.linux": "/usr/local/bin/radian",
+        "git.confirmSync": false,
+        "workbench.settings.editor": "json"
+      }
+    }
+  }
+}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: shiny.telemetry
 Title: 'Shiny' App Usage Telemetry
-Version: 0.3.1
+Version: 0.3.1.9001
 Authors@R: c(
     person("André", "Veríssimo", , "opensource+andre@appsilon.com", role = c("aut", "cre")),
     person("Kamil", "Żyła", , "kamil@appsilon.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# shiny.telemetry 0.3.1.9001
+
+### New Features
+
+- Added a dropdown to the `analytics_app()` to switch between applications.
+
 # shiny.telemetry 0.3.1
 
 ### New Features

--- a/R/analytics-app.R
+++ b/R/analytics-app.R
@@ -65,6 +65,13 @@ analytics_ui <- function() {
             "download_data", "Download", style = "margin-left: 2em;"
           )
         )
+      ),
+      semantic.dashboard::menuItem(
+        shiny.semantic::selectInput(
+          inputId = "app_name",
+          label = shiny::tags$label("Application name", shiny.semantic::icon("laptop")),
+          choices = character()
+        )
       )
     )
   )

--- a/R/prepare-admin-panel.R
+++ b/R/prepare-admin-panel.R
@@ -177,7 +177,7 @@ prepare_admin_panel_components <- function(
   })
 
   shiny::observeEvent(full_log_data(), {
-        applications <- sort(unique(full_log_data()$app_name)) %||% character(0L)
+    applications <- sort(unique(full_log_data()$app_name)) %||% character(0L)
     shiny.semantic::update_dropdown_input(
       session = session,
       input_id = "app_name",

--- a/R/prepare-admin-panel.R
+++ b/R/prepare-admin-panel.R
@@ -177,10 +177,7 @@ prepare_admin_panel_components <- function(
   })
 
   shiny::observeEvent(full_log_data(), {
-    applications <- unique(full_log_data()$app_name)
-    if (length(applications) == 0) {
-      applications <- character()
-    }
+        applications <- sort(unique(full_log_data()$app_name)) %||% character(0L)
     shiny.semantic::update_dropdown_input(
       session = session,
       input_id = "app_name",

--- a/R/prepare-admin-panel.R
+++ b/R/prepare-admin-panel.R
@@ -168,12 +168,31 @@ prepare_admin_panel_components <- function(
 
   hour_levels <- c("12am", paste0(1:11, "am"), "12pm", paste0(1:11, "pm"))
 
-  log_data <- shiny::reactive({
+  full_log_data <- shiny::reactive({
     shiny::req(input$date_from, input$date_to)
 
     data_storage$read_event_data(
       as.Date(input$date_from), as.Date(input$date_to)
     )
+  })
+
+  shiny::observeEvent(full_log_data(), {
+    applications <- unique(full_log_data()$app_name)
+    if (length(applications) == 0) {
+      applications <- character()
+    }
+    shiny.semantic::update_dropdown_input(
+      session = session,
+      input_id = "app_name",
+      choices = applications,
+      value = applications[1]
+    )
+  })
+
+  log_data <- shiny::reactive({
+    shiny::req(input$app_name)
+    full_log_data() |>
+      dplyr::filter(.data$app_name == input$app_name)
   })
 
   is_log_empty <- shiny::reactive(nrow(shiny::req(log_data())) == 0)

--- a/R/prepare-admin-panel.R
+++ b/R/prepare-admin-panel.R
@@ -188,7 +188,7 @@ prepare_admin_panel_components <- function(
 
   log_data <- shiny::reactive({
     shiny::req(input$app_name)
-    full_log_data() |>
+    full_log_data() %>%
       dplyr::filter(.data$app_name == input$app_name)
   })
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -20,3 +20,4 @@ replicaSet
 scalable
 ssl
 tabset
+dropdown


### PR DESCRIPTION
Closes #194 

### Changes description

This PR introduces the UI and server changes to be able to switch between multiple application logs. If there is only one application, it should not be a problem: the dropdown will have only one choice.

I thought about the alternative idea to have multiple apps at once, but I think it would blow the scope of this issue too much, since it would require careful considerations for how the plots are aggregated.

As a side-track bonus, I have added devcontainer configuration that installs all required packages and allows the developer to work either in VS Code or in RStudio. You can even run docker-compose inside this docker container.

### How to test

You can test it the way you are used to, but the way I do it with the devcontainer:
- open the folder in vscode, then reopen in devcontainer
- wait for all processes to complete (takes some time)
- then start the telemetry database with
```sh
cd inst/examples/postgres
docker-compose up
```
- then start r session by running ctrl+shift+p -> attach active r terminal
- in the R console
```r
devtools::load_all()
shiny::shinyAppFile(system.file("examples", "postgresql", "postgres_app.R", package = "shiny.telemetry"))
```

- then edit the postgres_app.R to feature a different app_name, and repeat the previous step
- finally run the postgres analytics app in a similar way to see the result

This is what I'm able to see:
![CleanShot 2024-12-12 at 19 30 58](https://github.com/user-attachments/assets/706a201e-6e3a-441a-a9d5-89380914f9e8)

### Definition of done

- [x] *Have you read the [Contributing Guidelines](https://github.com/Appsilon/shiny.telemetry/blob/main/CONTRIBUTING.md)?*
- [x] `NEWS.md` file has been updated
- [x] Development version has been bumped (`x.y.z.90XX`)
- [x] Issue has been linked with this PR _(via [Closing keywords](https://docs.github.com/articles/closing-issues-using-keywords) or right sidebar under `Development`)_
